### PR TITLE
Support zip archival format

### DIFF
--- a/docs/examples/config.yaml
+++ b/docs/examples/config.yaml
@@ -32,7 +32,10 @@ profiles:
       compress: 1  # Optional: Compression level (0-5)
     - name: tar_gz
       provider: tar
-      compress: gz  # Optional: Compressor [ bz2 | gz | xz ]
+      compress: gz  # Optional: Compression ( bz2 | gz | xz )
+    - name: zip_bz
+      provider: zip
+      compress: bz2  # Optional: Compression ( bz2 | gz | xz )
 
   # Uploader Profiles
   upload:

--- a/src/nimbuscli/cmd/factory.py
+++ b/src/nimbuscli/cmd/factory.py
@@ -9,7 +9,7 @@ from nimbuscli.cmd.backup import Backup
 from nimbuscli.cmd.command import Command
 from nimbuscli.cmd.deploy import Down, Up
 from nimbuscli.config import Config
-from nimbuscli.core.archive import Archiver, RarArchiver, TarArchiver
+from nimbuscli.core.archive import Archiver, RarArchiver, TarArchiver, ZipArchiver
 from nimbuscli.core.execute import SubprocessRunner
 from nimbuscli.core.upload import AwsUploader, Uploader
 from nimbuscli.provider import (
@@ -84,6 +84,8 @@ class CfgCommandFactory(CommandFactory):
                     return RarArchiver(SubprocessRunner(), cfg.password, cfg.compress, cfg.recovery)
                 case "tar":
                     return TarArchiver(cfg.compress)
+                case "zip":
+                    return ZipArchiver(cfg.compress)
 
         return None
 

--- a/src/nimbuscli/core/archive/__init__.py
+++ b/src/nimbuscli/core/archive/__init__.py
@@ -1,3 +1,4 @@
 from nimbuscli.core.archive.archiver import ArchivalStatus, Archiver
 from nimbuscli.core.archive.rar import RarArchivalStatus, RarArchiver
 from nimbuscli.core.archive.tar import TarArchiver
+from nimbuscli.core.archive.zip import ZipArchiver

--- a/src/nimbuscli/core/archive/rar.py
+++ b/src/nimbuscli/core/archive/rar.py
@@ -102,7 +102,9 @@ class RarArchiver(Archiver):
 class RarArchivalStatus(ArchivalStatus):
 
     def __init__(self, proc: CompletedProcess, directory: str, archive: str):
-        super().__init__(directory, archive, proc.started, proc.completed)
+        super().__init__(directory, archive)
+        self.started = proc.started
+        self.completed = proc.completed
         self.proc = proc
 
     @property

--- a/src/nimbuscli/core/archive/rar.py
+++ b/src/nimbuscli/core/archive/rar.py
@@ -30,17 +30,14 @@ class RarArchiver(Archiver):
         if runner is None:
             raise ValueError("The runner cannot be None")
 
-        if password is not None:
-            if password == "":
-                raise ValueError("If password is specified, it cannot be empty string")
+        if password is not None and password == "":
+            raise ValueError("If password is specified, it cannot be empty string.")
 
-        if compression is not None:
-            if not 0 <= compression <= 5:
-                raise ValueError("Compression should be in range [0-5]")
+        if compression is not None and not 0 <= compression <= 5:
+            raise ValueError("Compression should be either None or in [0-5] range.")
 
-        if recovery is not None:
-            if not 0 <= recovery <= 1000:
-                raise ValueError("Recovery should be in range [0-1000]")
+        if recovery is not None and not 0 <= recovery <= 1000:
+            raise ValueError("Recovery should be either None or in [0-1000] range.")
 
         self._runner = runner
         self._password = password

--- a/src/nimbuscli/core/archive/tar.py
+++ b/src/nimbuscli/core/archive/tar.py
@@ -1,14 +1,13 @@
 import logging
-import os
 import tarfile
-from datetime import datetime
+from typing import ContextManager
 
-from logdecorator import log_on_end, log_on_start
+from logdecorator import log_on_error
 
-from nimbuscli.core.archive.archiver import ArchivalStatus, Archiver
+from nimbuscli.core.archive.archiver import FSArchiver
 
 
-class TarArchiver(Archiver):
+class TarArchiver(FSArchiver):
     """
     Creates tar archives, including those using gzip, bz2 and lzma compression.
     """
@@ -37,15 +36,11 @@ class TarArchiver(Archiver):
     def extension(self) -> str:
         return "tar" if self._compression is None else f"tar.{self._compression}"
 
-    @log_on_start(logging.INFO, "Archiving {directory!s} -> {archive!s}")
-    @log_on_end(logging.INFO, "Archived [{result.success!s}]: {archive!s}")
-    def archive(self, directory: str, archive: str) -> ArchivalStatus:
-        started = datetime.now()
+    @log_on_error(logging.ERROR, "Failed init archiver: {e!r}", on_exceptions=Exception)
+    def init_archiver(self, archive: str) -> ContextManager:
         mode = "w" if self._compression is None else f"w:{self._compression}"
-        with tarfile.open(archive, mode) as tar:
-            for root, _, files in os.walk(directory):
-                for file in files:
-                    file_path = os.path.join(root, file)
-                    file_name = os.path.relpath(file_path, directory)
-                    tar.add(file_path, arcname=file_name)
-        return ArchivalStatus(directory, archive, started, datetime.now())
+        return tarfile.open(archive, mode)
+
+    @log_on_error(logging.ERROR, "Failed to add file: {e!r}", on_exceptions=Exception)
+    def add_file(self, arc: tarfile.TarFile, file_path: str, file_name: str) -> None:
+        arc.add(file_path, arcname=file_name)

--- a/src/nimbuscli/core/archive/tar.py
+++ b/src/nimbuscli/core/archive/tar.py
@@ -19,9 +19,9 @@ class TarArchiver(Archiver):
 
         :param compressor: Data compression method.
             You can specify the following values:
-                - bz2 - Creates Tarfile with bzip2 compression.
                 - gz - Creates Tarfile with gzip compression.
                 - xz - Creates Tarfile with lzma compression.
+                - bz2 - Creates Tarfile with bzip2 compression.
         """
 
         if compression is not None:

--- a/src/nimbuscli/core/archive/tar.py
+++ b/src/nimbuscli/core/archive/tar.py
@@ -13,7 +13,7 @@ class TarArchiver(Archiver):
     Creates tar archives, including those using gzip, bz2 and lzma compression.
     """
 
-    def __init__(self, compression: str = None):
+    def __init__(self, compression: str | None = None):
         """
         Creates a new instance of the TarArchiver.
 
@@ -24,9 +24,8 @@ class TarArchiver(Archiver):
                 - bz2 - Creates Tarfile with bzip2 compression.
         """
 
-        if compression is not None:
-            if compression not in ("bz2", "gz", "xz"):
-                raise ValueError("Compression should be None or one of: 'bz2', 'gz' or 'xz'.")
+        if compression not in (None, "bz2", "gz", "xz"):
+            raise ValueError("Compression should be None or one of: 'bz2', 'gz' or 'xz'.")
 
         self._compression = compression
 

--- a/src/nimbuscli/core/archive/zip.py
+++ b/src/nimbuscli/core/archive/zip.py
@@ -13,7 +13,7 @@ class ZipArchiver(Archiver):
     Creates zip archives, including ZIP64 extensions.
     """
 
-    def __init__(self, compression: str = None):
+    def __init__(self, compression: str | None = None):
         """
         Creates a new instance of the ZipArchiver.
 
@@ -24,9 +24,8 @@ class ZipArchiver(Archiver):
                 - bz2 - Creates zipfile with bzip2 compression.
         """
 
-        if compression is not None:
-            if compression not in ("bz2", "gz", "xz"):
-                raise ValueError("Compression should be None or one of: 'bz2', 'gz' or 'xz'.")
+        if compression not in (None, "bz2", "gz", "xz"):
+            raise ValueError("Compression should be None or one of: 'bz2', 'gz' or 'xz'.")
 
         self._compression: int = {
             None: zipfile.ZIP_STORED,

--- a/src/nimbuscli/core/archive/zip.py
+++ b/src/nimbuscli/core/archive/zip.py
@@ -19,9 +19,9 @@ class ZipArchiver(Archiver):
 
         :param compression: Data compression method.
             You can specify the following values:
-                - zip - Uses usual ZIP compression method.
-                - bz2 - Uses BZIP2 compression method.
-                - xz - Uses LZMA compression method.
+                - gz - Creates zipfile with gzip compression.
+                - xz - Creates zipfile with lzma compression.
+                - bz2 - Creates zipfile with bzip2 compression.
         """
 
         if compression is not None:

--- a/tests/core/archive/test_tar.py
+++ b/tests/core/archive/test_tar.py
@@ -11,25 +11,25 @@ from tests.helpers import MockDateTime
 class TestTarArchiver:
 
     @pytest.mark.parametrize(
-        "compressor",
+        "compression",
         ["bz2", "gz", "xz", None],
     )
-    def test_init(self, compressor):
-        archiver = TarArchiver(compressor)
-        assert archiver._compressor == compressor
+    def test_init(self, compression):
+        archiver = TarArchiver(compression)
+        assert archiver._compression == compression
 
-        if compressor is None:
+        if compression is None:
             assert archiver.extension == "tar"
         else:
-            assert archiver.extension == f"tar.{compressor}"
+            assert archiver.extension == f"tar.{compression}"
 
     @pytest.mark.parametrize(
-        "compressor",
+        "compression",
         ["value", "dif", "lz", "lzma", "lzop", "zstd"],
     )
-    def test_init_failed_params(self, compressor):
+    def test_init_failed_params(self, compression):
         with pytest.raises(ValueError):
-            TarArchiver(compressor)
+            TarArchiver(compression)
 
     @patch("tarfile.open")
     @patch("os.walk")

--- a/tests/core/archive/test_zip.py
+++ b/tests/core/archive/test_zip.py
@@ -35,7 +35,7 @@ class TestZipArchiver:
 
     @patch("zipfile.ZipFile")
     @patch("os.walk")
-    @patch("nimbuscli.core.archive.zip.datetime", MockDateTime)
+    @patch("nimbuscli.core.archive.archiver.datetime", MockDateTime)
     def test_archive(self, os_walk, zipfile_mock):
         directory = "DIRECTORY_PATH/abc"
         archive = "archive/abc.zip"
@@ -60,6 +60,7 @@ class TestZipArchiver:
         assert res.completed == completed
         assert res.directory == directory
         assert res.archive == archive
+        assert res.exception is None
 
         zipfile_mock.assert_called_with(archive, "w", zipfile.ZIP_DEFLATED)
         os_walk.assert_called_with(directory)

--- a/tests/core/archive/test_zip.py
+++ b/tests/core/archive/test_zip.py
@@ -1,0 +1,76 @@
+import os
+import zipfile
+from datetime import datetime as dt
+
+import pytest
+from mock import Mock, call, patch
+
+from nimbuscli.core.archive.zip import ZipArchiver
+from tests.helpers import MockDateTime
+
+
+class TestZipArchiver:
+
+    @pytest.mark.parametrize(
+        ["compression", "expected"],
+        [
+            ("bz2", zipfile.ZIP_BZIP2),
+            ("gz", zipfile.ZIP_DEFLATED),
+            ("xz", zipfile.ZIP_LZMA),
+            (None, zipfile.ZIP_STORED),
+        ],
+    )
+    def test_init(self, compression, expected):
+        archiver = ZipArchiver(compression)
+        assert archiver.extension == "zip"
+        assert archiver._compression == expected
+
+    @pytest.mark.parametrize(
+        "compression",
+        ["value", "dif", "lz", "lzma", "lzop", "zstd"],
+    )
+    def test_init_failed_params(self, compression):
+        with pytest.raises(ValueError):
+            ZipArchiver(compression)
+
+    @patch("zipfile.ZipFile")
+    @patch("os.walk")
+    @patch("nimbuscli.core.archive.zip.datetime", MockDateTime)
+    def test_archive(self, os_walk, zipfile_mock):
+        directory = "DIRECTORY_PATH/abc"
+        archive = "archive/abc.zip"
+        started = dt(2024, 1, 1, 10, 00, 00)
+        completed = dt(2024, 1, 1, 10, 30, 15)
+        MockDateTime.now_returns(started, completed)
+
+        zip_mock = Mock()
+        zipfile_mock.return_value.__enter__.return_value = zip_mock
+
+        os_walk.return_value = [
+            (directory, ["subA", "subB"], ["file1", "file2"]),
+            (os.path.join(directory, "subA"), ["subAA"], ["fileA1", "fileA2"]),
+            (os.path.join(directory, "subA", "subAA"), [], ["fileAA1"]),
+            (os.path.join(directory, "subB"), ["subB"], ["fileB1", "fileB2"]),
+        ]
+
+        zipf = ZipArchiver("gz")
+        res = zipf.archive(directory, archive)
+
+        assert res.started == started
+        assert res.completed == completed
+        assert res.directory == directory
+        assert res.archive == archive
+
+        zipfile_mock.assert_called_with(archive, "w", zipfile.ZIP_DEFLATED)
+        os_walk.assert_called_with(directory)
+        zip_mock.write.assert_has_calls(
+            [
+                call(os.path.join(directory, "file1"), arcname="file1"),
+                call(os.path.join(directory, "file2"), arcname="file2"),
+                call(os.path.join(directory, "subA/fileA1"), arcname="subA/fileA1"),
+                call(os.path.join(directory, "subA/fileA2"), arcname="subA/fileA2"),
+                call(os.path.join(directory, "subA/subAA/fileAA1"), arcname="subA/subAA/fileAA1"),
+                call(os.path.join(directory, "subB/fileB1"), arcname="subB/fileB1"),
+                call(os.path.join(directory, "subB/fileB2"), arcname="subB/fileB2"),
+            ]
+        )


### PR DESCRIPTION
### Description
Added support for zip archives, including those using gzip, bz2 and lzma compression.

### Configuration change
Archive profiles could use zip provider, with an optional bz2, gz or xz compressor.

```yaml
profiles:
  archive:
    - name: zip_gz
      provider: zip
      compress: gz  # Optional: Compressor [ bz2 | gz | xz ]
```

### Related issues
Closes #9 